### PR TITLE
Fix worktrees failing to open on WSL: translate POSIX worktree paths to UNC

### DIFF
--- a/patches/01-wsl-path-detection.patch
+++ b/patches/01-wsl-path-detection.patch
@@ -1,9 +1,9 @@
 diff --git a/app/src/lib/wsl.ts b/app/src/lib/wsl.ts
 new file mode 100644
-index 0000000..ecc8009
+index 0000000..1288da2
 --- /dev/null
 +++ b/app/src/lib/wsl.ts
-@@ -0,0 +1,495 @@
+@@ -0,0 +1,523 @@
 +/**
 + * WSL utilities and daemon client for GitHub Desktop WSL.
 + *
@@ -54,6 +54,34 @@ index 0000000..ecc8009
 +    distro: start.slice(0, slashIdx),
 +    linuxPath: start.slice(slashIdx).replace(/\\/g, '/'),
 +  }
++}
++
++/**
++ * Build a Windows WSL UNC path for a POSIX path inside a distro.
++ * Inverse of parseWSLPath / toLinuxPath.
++ * ('Ubuntu-24.04', '/home/user') → \\wsl.localhost\Ubuntu-24.04\home\user
++ *
++ * Accepts either a real POSIX path ('/home/user') or one that has already
++ * been run through Path.normalize on Windows ('\home\user'): both are
++ * separator-normalised to backslashes before the UNC prefix is prepended.
++ */
++export function linuxPathToWSL(distro: string, linuxPath: string): string {
++  return `\\\\wsl.localhost\\${distro}${linuxPath.replace(/\//g, '\\')}`
++}
++
++/**
++ * True for a path that is rooted at the filesystem root but has no Windows
++ * volume — i.e. a POSIX absolute path ('/home/user') or the string that
++ * Path.normalize produces from one on Windows ('\home\user', a single leading
++ * backslash, not a '\\' UNC path). These are the worktree paths git returns
++ * inside WSL; Windows cannot resolve them until they are lifted to a UNC path.
++ * Drive-letter paths ('C:\...') and UNC paths ('\\...') return false.
++ */
++export function isRootlessPosixPath(p: string): boolean {
++  if (/^[a-zA-Z]:[\\/]/.test(p)) {
++    return false
++  }
++  return p.startsWith('/') || (p.startsWith('\\') && !p.startsWith('\\\\'))
 +}
 +
 +/** Resolve WSL path to { distro, linuxPath }, caching and persisting the distro. */

--- a/patches/07-worktree-path-translation.patch
+++ b/patches/07-worktree-path-translation.patch
@@ -1,8 +1,8 @@
 diff --git a/app/src/lib/git/worktree.ts b/app/src/lib/git/worktree.ts
-index bec61a1..375ed3a 100644
+index e1d99d1..21538f1 100644
 --- a/app/src/lib/git/worktree.ts
 +++ b/app/src/lib/git/worktree.ts
-@@ -2,6 +2,12 @@ import * as Path from 'path'
+@@ -2,6 +2,35 @@ import * as Path from 'path'
  import type { Repository } from '../../models/repository'
  import type { WorktreeEntry, WorktreeType } from '../../models/worktree'
  import { git } from './core'
@@ -12,10 +12,33 @@ index bec61a1..375ed3a 100644
 +  linuxPathToWSL,
 +  parseWSLPath,
 +} from '../wsl'
++
++/**
++ * On WSL, git runs inside the distro and returns POSIX worktree paths
++ * (/home/user/...). parseWorktreePorcelainOutput runs each through
++ * Path.normalize, which on Windows only flips separators (\home\user\...) —
++ * still rootless, so Windows cannot resolve it and the worktree fails to
++ * open. Lift those paths to \\wsl.localhost\<distro>\... using the distro of
++ * the (already-UNC) reference path. Native Windows paths are left untouched.
++ */
++function translateWorktreePaths(
++  entries: ReadonlyArray<WorktreeEntry>,
++  referencePath: string
++): ReadonlyArray<WorktreeEntry> {
++  if (!isWSLPath(referencePath)) {
++    return entries
++  }
++  const { distro } = parseWSLPath(referencePath)
++  return entries.map(entry =>
++    isRootlessPosixPath(entry.path)
++      ? { ...entry, path: linuxPathToWSL(distro, entry.path) }
++      : entry
++  )
++}
  
  export function parseWorktreePorcelainOutput(
    stdout: string
-@@ -55,15 +61,35 @@ export function parseWorktreePorcelainOutput(
+@@ -55,15 +84,21 @@ export function parseWorktreePorcelainOutput(
  export async function listWorktrees(
    repositoryOrPath: Repository | string
  ): Promise<ReadonlyArray<WorktreeEntry>> {
@@ -34,63 +57,19 @@ index bec61a1..375ed3a 100644
    )
  
 -  return parseWorktreePorcelainOutput(result.stdout)
-+  const entries = parseWorktreePorcelainOutput(result.stdout)
-+
-+  // On WSL, git runs inside the distro and returns POSIX worktree paths
-+  // (/home/user/...). parseWorktreePorcelainOutput runs each through
-+  // Path.normalize, which on Windows only flips separators (\home\user\...) —
-+  // still rootless, so Windows cannot resolve it and the worktree fails to
-+  // open. Lift those paths to \\wsl.localhost\<distro>\... using the distro of
-+  // the (already-UNC) repository path. Native Windows paths are left untouched.
-+  if (isWSLPath(repositoryPath)) {
-+    const { distro } = parseWSLPath(repositoryPath)
-+    return entries.map(entry =>
-+      isRootlessPosixPath(entry.path)
-+        ? { ...entry, path: linuxPathToWSL(distro, entry.path) }
-+        : entry
-+    )
-+  }
-+
-+  return entries
++  return translateWorktreePaths(
++    parseWorktreePorcelainOutput(result.stdout),
++    repositoryPath
++  )
+ }
+ 
+ export async function listWorktreesFromGitDir(
+@@ -75,7 +110,7 @@ export async function listWorktreesFromGitDir(
+     'listWorktreesFromGitDir'
+   )
+ 
+-  return parseWorktreePorcelainOutput(result.stdout)
++  return translateWorktreePaths(parseWorktreePorcelainOutput(result.stdout), gitDir)
  }
  
  export async function addWorktree(
-diff --git a/app/src/lib/wsl.ts b/app/src/lib/wsl.ts
-index ecc8009..1288da2 100644
---- a/app/src/lib/wsl.ts
-+++ b/app/src/lib/wsl.ts
-@@ -50,6 +50,34 @@ export function parseWSLPath(winPath: string): {
-   }
- }
- 
-+/**
-+ * Build a Windows WSL UNC path for a POSIX path inside a distro.
-+ * Inverse of parseWSLPath / toLinuxPath.
-+ * ('Ubuntu-24.04', '/home/user') → \\wsl.localhost\Ubuntu-24.04\home\user
-+ *
-+ * Accepts either a real POSIX path ('/home/user') or one that has already
-+ * been run through Path.normalize on Windows ('\home\user'): both are
-+ * separator-normalised to backslashes before the UNC prefix is prepended.
-+ */
-+export function linuxPathToWSL(distro: string, linuxPath: string): string {
-+  return `\\\\wsl.localhost\\${distro}${linuxPath.replace(/\//g, '\\')}`
-+}
-+
-+/**
-+ * True for a path that is rooted at the filesystem root but has no Windows
-+ * volume — i.e. a POSIX absolute path ('/home/user') or the string that
-+ * Path.normalize produces from one on Windows ('\home\user', a single leading
-+ * backslash, not a '\\' UNC path). These are the worktree paths git returns
-+ * inside WSL; Windows cannot resolve them until they are lifted to a UNC path.
-+ * Drive-letter paths ('C:\...') and UNC paths ('\\...') return false.
-+ */
-+export function isRootlessPosixPath(p: string): boolean {
-+  if (/^[a-zA-Z]:[\\/]/.test(p)) {
-+    return false
-+  }
-+  return p.startsWith('/') || (p.startsWith('\\') && !p.startsWith('\\\\'))
-+}
-+
- /** Resolve WSL path to { distro, linuxPath }, caching and persisting the distro. */
- function resolveWSLPath(winPath: string): { distro: string; linuxPath: string } {
-   const result = parseWSLPath(winPath)

--- a/patches/07-worktree-path-translation.patch
+++ b/patches/07-worktree-path-translation.patch
@@ -1,0 +1,96 @@
+diff --git a/app/src/lib/git/worktree.ts b/app/src/lib/git/worktree.ts
+index bec61a1..375ed3a 100644
+--- a/app/src/lib/git/worktree.ts
++++ b/app/src/lib/git/worktree.ts
+@@ -2,6 +2,12 @@ import * as Path from 'path'
+ import type { Repository } from '../../models/repository'
+ import type { WorktreeEntry, WorktreeType } from '../../models/worktree'
+ import { git } from './core'
++import {
++  isWSLPath,
++  isRootlessPosixPath,
++  linuxPathToWSL,
++  parseWSLPath,
++} from '../wsl'
+ 
+ export function parseWorktreePorcelainOutput(
+   stdout: string
+@@ -55,15 +61,35 @@ export function parseWorktreePorcelainOutput(
+ export async function listWorktrees(
+   repositoryOrPath: Repository | string
+ ): Promise<ReadonlyArray<WorktreeEntry>> {
+-  const result = await git(
+-    ['worktree', 'list', '--porcelain', '-z'],
++  const repositoryPath =
+     typeof repositoryOrPath === 'string'
+       ? repositoryOrPath
+-      : repositoryOrPath.path,
++      : repositoryOrPath.path
++
++  const result = await git(
++    ['worktree', 'list', '--porcelain', '-z'],
++    repositoryPath,
+     'listWorktrees'
+   )
+ 
+-  return parseWorktreePorcelainOutput(result.stdout)
++  const entries = parseWorktreePorcelainOutput(result.stdout)
++
++  // On WSL, git runs inside the distro and returns POSIX worktree paths
++  // (/home/user/...). parseWorktreePorcelainOutput runs each through
++  // Path.normalize, which on Windows only flips separators (\home\user\...) —
++  // still rootless, so Windows cannot resolve it and the worktree fails to
++  // open. Lift those paths to \\wsl.localhost\<distro>\... using the distro of
++  // the (already-UNC) repository path. Native Windows paths are left untouched.
++  if (isWSLPath(repositoryPath)) {
++    const { distro } = parseWSLPath(repositoryPath)
++    return entries.map(entry =>
++      isRootlessPosixPath(entry.path)
++        ? { ...entry, path: linuxPathToWSL(distro, entry.path) }
++        : entry
++    )
++  }
++
++  return entries
+ }
+ 
+ export async function addWorktree(
+diff --git a/app/src/lib/wsl.ts b/app/src/lib/wsl.ts
+index ecc8009..1288da2 100644
+--- a/app/src/lib/wsl.ts
++++ b/app/src/lib/wsl.ts
+@@ -50,6 +50,34 @@ export function parseWSLPath(winPath: string): {
+   }
+ }
+ 
++/**
++ * Build a Windows WSL UNC path for a POSIX path inside a distro.
++ * Inverse of parseWSLPath / toLinuxPath.
++ * ('Ubuntu-24.04', '/home/user') → \\wsl.localhost\Ubuntu-24.04\home\user
++ *
++ * Accepts either a real POSIX path ('/home/user') or one that has already
++ * been run through Path.normalize on Windows ('\home\user'): both are
++ * separator-normalised to backslashes before the UNC prefix is prepended.
++ */
++export function linuxPathToWSL(distro: string, linuxPath: string): string {
++  return `\\\\wsl.localhost\\${distro}${linuxPath.replace(/\//g, '\\')}`
++}
++
++/**
++ * True for a path that is rooted at the filesystem root but has no Windows
++ * volume — i.e. a POSIX absolute path ('/home/user') or the string that
++ * Path.normalize produces from one on Windows ('\home\user', a single leading
++ * backslash, not a '\\' UNC path). These are the worktree paths git returns
++ * inside WSL; Windows cannot resolve them until they are lifted to a UNC path.
++ * Drive-letter paths ('C:\...') and UNC paths ('\\...') return false.
++ */
++export function isRootlessPosixPath(p: string): boolean {
++  if (/^[a-zA-Z]:[\\/]/.test(p)) {
++    return false
++  }
++  return p.startsWith('/') || (p.startsWith('\\') && !p.startsWith('\\\\'))
++}
++
+ /** Resolve WSL path to { distro, linuxPath }, caching and persisting the distro. */
+ function resolveWSLPath(winPath: string): { distro: string; linuxPath: string } {
+   const result = parseWSLPath(winPath)

--- a/scripts/generate-patches.sh
+++ b/scripts/generate-patches.sh
@@ -76,6 +76,11 @@ echo "06-build-packaging.patch"
 git diff "$BASE_COMMIT"..HEAD -- script/build.ts script/package.ts \
     > "$PATCHES_DIR/06-build-packaging.patch"
 
+# Patch 07: Worktree path translation (POSIX → UNC, helpers live in wsl.ts / patch 01)
+echo "07-worktree-path-translation.patch"
+git diff "$BASE_COMMIT"..HEAD -- app/src/lib/git/worktree.ts \
+    > "$PATCHES_DIR/07-worktree-path-translation.patch"
+
 echo ""
 echo "Generated patches:"
 ls -la "$PATCHES_DIR"/*.patch


### PR DESCRIPTION
Fixes #62.

## Problem

Worktrees on a WSL repo fail to open (`\home\...` invalid). git returns POSIX worktree paths; upstream `parseWorktreePorcelainOutput` runs them through `Path.normalize`, which on Windows only flips separators (`/home` → `\home`) without adding a volume, leaving a rootless path Windows can't resolve. The repo path works because it comes from the folder picker (correct UNC); only git-discovered worktree paths are left untranslated. Full analysis in #62.

## Change

New patch `patches/07-worktree-path-translation.patch`, following the numbered `git apply` convention. Two hunks, entirely within the fork's own code:

**`app/src/lib/wsl.ts`** — add two exported helpers:
- `linuxPathToWSL(distro, linuxPath)` — inverse of `parseWSLPath`; builds `\\wsl.localhost\<distro>\...`.
- `isRootlessPosixPath(p)` — true for a POSIX-rooted path, **including the backslash-flipped form** `Path.normalize` yields on Windows (`\home\...`, a single leading backslash, not a `\\` UNC path). Drive-letter and UNC paths return false.

**`app/src/lib/git/worktree.ts`** — in `listWorktrees` (not the parser): the parser only receives `stdout` and has no repo context, whereas `listWorktrees` has the `Repository` → `.path` → distro. After parsing, if the repo is a WSL path, lift rootless worktree entry paths to UNC.

## Design guards

- **Distro derived** from the parent repo's UNC path via `parseWSLPath` — never hardcoded (`Ubuntu`, etc.).
- Translate **only** when the repo is WSL (`isWSLPath`) **and** the entry path is rootless. Native Windows paths pass untouched.
- Guards on the **post-`Path.normalize`** form: on Windows the path is already `\home\...`, so a naive `startsWith('/')` check would miss it — `isRootlessPosixPath` handles both `/home` and `\home`.
- Assumes the worktree lives on the **same distro** as its parent (true for the normal case and for `.claude/worktrees/`). Cross-distro worktrees would get the wrong prefix — documented known edge, not handled.
- Scoped to worktrees; submodule paths (`submodule.ts`) likely share the bug — flagged as a separate follow-up in #62, not touched here.

## Verification

- Patches **01–07 apply cleanly** with `git apply` against a pristine `desktop/desktop@release-3.6.2` checkout (current latest upstream `release-*` tag). Hunks use minimal, stable context anchors.
- No upstream automated test suite for this path → **manual E2E** (I cannot run the Windows build here; leaving final E2E to a WSL+Windows environment):
  1. In WSL, create a repo with ≥1 worktree (`git worktree add`).
  2. Add the parent repo in the built app.
  3. Confirm each worktree **opens**, shows the **correct branch**, and diffs load.
  4. Before/after screenshots.

## Risk

Patch fragility — CI applies patches with strict `git apply` against each new `release-*` every 6h. The `worktree.ts` hunk is anchored on the stable `listWorktrees` shape; re-diff if upstream restructures it. Re-verify against the live tag at merge time (do not assume 3.6.2 if a newer tag has shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
